### PR TITLE
Feature/deploy on gke

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,7 +23,9 @@ steps:
       '--platform',
       'gke',
       '--cluster',
-      'poltio-cluster-1']
+      'poltio-cluster-1',
+      '--cluster-location',
+      'europe-west1-b']
 
 images:
   - gcr.io/poltio-164412/poltio-ip

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
     # Deploy container image to Cloud Run
   - name: 'gcr.io/cloud-builders/gcloud'
     args: [
-      'beta',
+      'alpha',
       'run',
       'deploy',
       'poltio-ip-${_ENV}',
@@ -25,7 +25,9 @@ steps:
       '--cluster',
       'poltio-cluster-1',
       '--cluster-location',
-      'europe-west1-b']
+      'europe-west1-b',
+      '--min-instances',
+      '1']
 
 images:
   - gcr.io/poltio-164412/poltio-ip

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,7 +23,9 @@ steps:
       '--region',
       'europe-west1',
       '--platform',
-      'managed',
+      'gke',
+      '--cluster',
+      'poltio-cluster-1',
       '--allow-unauthenticated']
 
 images:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,7 +25,9 @@ steps:
       '--cluster',
       'poltio-cluster-1',
       '--cluster-location',
-      'europe-west1-b']
+      'europe-west1-b',
+      '--min-instances',
+      '${_MIN_I}']
 
 images:
   - gcr.io/poltio-164412/poltio-ip

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,9 +25,7 @@ steps:
       '--cluster',
       'poltio-cluster-1',
       '--cluster-location',
-      'europe-west1-b',
-      '--min-instances',
-      '${_MIN_I}']
+      'europe-west1-b']
 
 images:
   - gcr.io/poltio-164412/poltio-ip

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,8 +20,6 @@ steps:
       'poltio-ip-${_ENV}',
       '--image',
       'gcr.io/poltio-164412/poltio-ip',
-      '--region',
-      'europe-west1',
       '--platform',
       'gke',
       '--cluster',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
       '--cluster-location',
       'europe-west1-b',
       '--min-instances',
-      '1']
+      '${_MIN_I}']
 
 images:
   - gcr.io/poltio-164412/poltio-ip

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,8 +25,7 @@ steps:
       '--platform',
       'gke',
       '--cluster',
-      'poltio-cluster-1',
-      '--allow-unauthenticated']
+      'poltio-cluster-1']
 
 images:
   - gcr.io/poltio-164412/poltio-ip


### PR DESCRIPTION
## Whats new

- Deploy with alpha instead of beta for supporting minimum instances
- Deploy to poltio-cluster-1 instead of fully managed cloud run. 


With this setup we will disable scale down to zero for IP service on production. 